### PR TITLE
Auto-detect report type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 Gemfile.lock
+coverage/
+spec/examples.txt

--- a/exe/email-report-processor
+++ b/exe/email-report-processor
@@ -9,7 +9,6 @@ require 'faraday/net_http_persistent'
 require 'optparse'
 
 options = {
-  class:   nil,
   mbox:    false,
   maildir: false,
   os:      {
@@ -42,15 +41,8 @@ class Progress
   end
 end
 
-OptionParser.new do |opts| # rubocop:disable Metrics/BlockLength
+OptionParser.new do |opts|
   opts.banner = "usage: #{$PROGRAM_NAME} [options] [file...]"
-  opts.separator("\nReport type selection:")
-  opts.on('-d', '--dmarc', 'Process DMARC Reports') do
-    options[:class] = EmailReportProcessor::DmarcRua
-  end
-  opts.on('-t', '--tlsrpt', 'Process SMTP TLS Reports') do
-    options[:class] = EmailReportProcessor::TlsrptRua
-  end
 
   opts.separator("\nOpenSearch options:")
   opts.on('-h', '--os-host=HOSTNAME', 'Hostname of the OpenSearch instance') do |host|
@@ -78,11 +70,6 @@ OptionParser.new do |opts| # rubocop:disable Metrics/BlockLength
   end
 end.parse!
 
-if options[:class].nil?
-  warn('A processor type must be passed')
-  exit 1
-end
-
 if options[:mbox] && options[:maildir]
   warn('The --mbox and --maildir options are mutualy exclusive')
   exit 1
@@ -95,7 +82,7 @@ client = OpenSearch::Client.new(
   transport_options: { ssl: { verify: false } },
 )
 
-processor = options[:class].new(client: client, options: options)
+processor = ReportProcessor.new(client: client, options: options)
 
 if ARGV.empty?
   mail = Mail.new($stdin.read)

--- a/features/dmarc.feature
+++ b/features/dmarc.feature
@@ -1,6 +1,6 @@
 Feature: Process DMARC reports
   Scenario: Process a DMARC report
-    Given I run `email-report-processor --dmarc` interactively
+    Given I run `email-report-processor` interactively
     When I pipe in the file "%/sample-reports/dmarc/report.elm"
     And I close the stdin stream
     Then the exit status should be 0

--- a/features/tlsrpt.feature
+++ b/features/tlsrpt.feature
@@ -1,6 +1,6 @@
 Feature: Process SMTP TLS reports
   Scenario: Process a SMTP TLS report
-    Given I run `email-report-processor --tlsrpt` interactively
+    Given I run `email-report-processor` interactively
     When I pipe in the file "%/sample-reports/tlsrpt/report.elm"
     And I close the stdin stream
     Then the exit status should be 0

--- a/lib/email_report_processor.rb
+++ b/lib/email_report_processor.rb
@@ -3,4 +3,5 @@
 require 'email_report_processor/mailbox'
 require 'email_report_processor/maildir'
 require 'email_report_processor/dmarc_rua'
+require 'email_report_processor/report_processor'
 require 'email_report_processor/tlsrpt_rua'

--- a/lib/email_report_processor/report_processor.rb
+++ b/lib/email_report_processor/report_processor.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class ReportProcessor
+  def initialize(client:, options:)
+    @processors = [
+      EmailReportProcessor::DmarcRua.new(client: client, options: options),
+      EmailReportProcessor::TlsrptRua.new(client: client, options: options),
+    ]
+  end
+
+  def process_message(mail)
+    processed = false
+
+    @processors.each do |processor|
+      processor.process_message(mail)
+      processed = true
+    rescue REXML::ParseException, JSON::ParserError
+      # ignore
+    end
+
+    return if processed
+
+    raise "No processor for report with Message-Id #{mail.message_id}"
+  end
+end


### PR DESCRIPTION
Remove the requirement to pass a report type as an option and the
limitation to process only this type of reports in a single command
invocation.
