### PR TITLE
Improve error reporting

### DIFF
--- a/exe/email-report-processor
+++ b/exe/email-report-processor
@@ -112,3 +112,11 @@ else
   end
   p.terminate
 end
+
+unless processor.errors.empty?
+  warn "The following #{processor.errors.count} message(s) count not be processed:"
+  processor.errors.each do |error|
+    warn "  - #{error.message_id} (#{error.subject})"
+  end
+  exit 1
+end

--- a/lib/email_report_processor/base.rb
+++ b/lib/email_report_processor/base.rb
@@ -40,7 +40,10 @@ module EmailReportProcessor
 
     def process_message(mail)
       part = mail.attachments.first || mail
-      filename = part['Content-Disposition'].filename
+      content_disposition = part['Content-Disposition']
+      return nil unless content_disposition
+
+      filename = content_disposition.filename
 
       process_attachment(filename, part.body.decoded)
     end


### PR DESCRIPTION
Do not fail hard on error, continue to proccess arguments and report the
message-id / subject of unprocessable mail at the end.
