### PR TITLE
Fix ingestion of DMARC reports without DKIM auth_results

### DIFF
--- a/lib/email_report_processor/dmarc_rua.rb
+++ b/lib/email_report_processor/dmarc_rua.rb
@@ -67,7 +67,7 @@ module EmailReportProcessor
       report = Hash.from_xml(raw_report)
 
       report_records(report).each do |record|
-        record['auth_results']['dkim'] = [record['auth_results']['dkim']].flatten.each_with_index.to_a.to_h(&:reverse)
+        flatten_record_dkim_auth_results(record) if record['auth_results']['dkim']
         report['feedback']['record'] = record
 
         send_report(report)
@@ -76,6 +76,10 @@ module EmailReportProcessor
 
     def report_records(report)
       [report['feedback']['record']].flatten.map(&:to_h)
+    end
+
+    def flatten_record_dkim_auth_results(record)
+      record['auth_results']['dkim'] = [record['auth_results']['dkim']].flatten.each_with_index.to_a.to_h(&:reverse)
     end
   end
 end

--- a/spec/email_report_processor/dmarc_rua_spec.rb
+++ b/spec/email_report_processor/dmarc_rua_spec.rb
@@ -20,10 +20,22 @@ RSpec.describe EmailReportProcessor::DmarcRua do
   describe '#report' do
     let(:raw_report) { File.read('spec/fixtures/sample-reports/dmarc/google.com!example.com!1705363200!1705449599.xml') }
 
-    it 'sends reports' do
+    before do
       allow(processor).to receive(:send_report)
       processor.report(raw_report)
+    end
+
+    it 'sends reports' do
       expect(processor).to have_received(:send_report)
+    end
+
+    context 'without DKIM' do
+      let(:raw_report) { File.read('spec/fixtures/sample-reports/dmarc/enterprise.protection.outlook.com!blogreen.org!1706572800!1706659200.xml') }
+
+      it 'does not include DKIM auth_results' do
+        expect(processor).to have_received(:send_report)
+          .with(hash_including('feedback' => hash_including('record' => hash_including('auth_results' => hash_not_including('dkim')))))
+      end
     end
   end
 end

--- a/spec/fixtures/sample-reports/dmarc/enterprise.protection.outlook.com!blogreen.org!1706572800!1706659200.xml
+++ b/spec/fixtures/sample-reports/dmarc/enterprise.protection.outlook.com!blogreen.org!1706572800!1706659200.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<feedback xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <version>1.0</version>
+  <report_metadata>
+    <org_name>Enterprise Outlook</org_name>
+    <email>dmarcreport@microsoft.com</email>
+    <report_id>76a4511632d34eb99e944bfa59537f71</report_id>
+    <date_range>
+      <begin>1706572800</begin>
+      <end>1706659200</end>
+    </date_range>
+  </report_metadata>
+  <policy_published>
+    <domain>blogreen.org</domain>
+    <adkim>r</adkim>
+    <aspf>r</aspf>
+    <p>reject</p>
+    <sp>reject</sp>
+    <pct>100</pct>
+    <fo>1</fo>
+  </policy_published>
+  <record>
+    <row>
+      <source_ip>217.70.183.201</source_ip>
+      <count>1</count>
+      <policy_evaluated>
+        <disposition>reject</disposition>
+        <dkim>fail</dkim>
+        <spf>fail</spf>
+      </policy_evaluated>
+    </row>
+    <identifiers>
+      <envelope_to>example.com</envelope_to>
+      <envelope_from>blogreen.org</envelope_from>
+      <header_from>blogreen.org</header_from>
+    </identifiers>
+    <auth_results>
+      <spf>
+        <domain>blogreen.org</domain>
+        <scope>mfrom</scope>
+        <result>fail</result>
+      </spf>
+    </auth_results>
+  </record>
+</feedback>


### PR DESCRIPTION
Some reports do not include DKIM auth\_results.  Trying to flatten these cause inconsistent document being generated.

Ensure we do not attempt to flatten a non-existent information to fix the issue.
