### PR TITLE
Rename MBox into Mbox

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,13 +36,5 @@ RSpec/MultipleMemoizedHelpers:
 Metrics/ClassLength:
   Max: 200
 
-RSpec/FilePath:
-  CustomTransform:
-    MBox: mbox
-
-RSpec/SpecFilePathFormat:
-  CustomTransform:
-    MBox: mbox
-
 RSpec/SubjectStub:
   Enabled: false

--- a/exe/email-report-processor
+++ b/exe/email-report-processor
@@ -95,7 +95,7 @@ else
   p = Progress.new
   ARGV.each do |filename|
     if options[:mbox]
-      m = EmailReportProcessor::MBox.new(filename)
+      m = EmailReportProcessor::Mbox.new(filename)
 
       while (mail = m.next_message)
         processor.process_message(mail)

--- a/lib/email_report_processor/mbox.rb
+++ b/lib/email_report_processor/mbox.rb
@@ -3,7 +3,7 @@
 require 'mail'
 
 module EmailReportProcessor
-  class MBox
+  class Mbox
     def initialize(filename)
       @io = File.open(filename)
       @current_message = ''

--- a/spec/email_report_processor/mbox_spec.rb
+++ b/spec/email_report_processor/mbox_spec.rb
@@ -2,7 +2,7 @@
 
 require 'email_report_processor/mbox'
 
-RSpec.describe EmailReportProcessor::MBox do
+RSpec.describe EmailReportProcessor::Mbox do
   subject(:mbox) { described_class.new('spec/fixtures/mbox/romain') }
 
   describe '#next' do


### PR DESCRIPTION
Not sure why I insisted on capitalizing the B, 'Mbox' seems quite
correct and usual.
