### PR TITLE
Add support for using ingestion pipeline

### DIFF
--- a/exe/email-report-processor
+++ b/exe/email-report-processor
@@ -62,8 +62,14 @@ OptionParser.new do |opts|
   opts.on('--dmarc-index=INDEX', 'OpenSearch index of DMARC reports') do |index|
     options[:dmarc_index] = index
   end
+  opts.on('--dmarc-pipeline=PIPELINE', 'Ingest DMARC reports using the provided PIPELINE') do |pipeline|
+    options[:dmarc_pipeline] = pipeline
+  end
   opts.on('--tlsrpt-index=INDEX', 'OpenSearch index of SMTP TLS reports') do |index|
     options[:tlsrpt_index] = index
+  end
+  opts.on('--tlsrpt-pipeline=PIPELINE', 'Ingest SMTP TLS reports using the provided PIPELINE') do |pipeline|
+    options[:tlsrpt_pipeline] = pipeline
   end
 
   opts.separator("\nMiscellaneous options:")

--- a/guides/advanced_usage.md
+++ b/guides/advanced_usage.md
@@ -1,0 +1,40 @@
+# Advanced usage
+
+## Add ASN Information to DMARC reports
+
+DMARC reports include the IP address of the machine which sent messages.
+In order to ease-up filtering, it is possible to enrich reports with the [GeoLite2 ASN Database](https://dev.maxmind.com/geoip/docs/databases/asn) to add `asn`, `network` and `organization_name` to them.
+This can be done using the [IP2Geo processor](https://opensearch.org/docs/latest/ingest-pipelines/processors/ip2geo/) (available since OpenSearch 2.10).
+
+1. Add an `asn` IP2Geo data source:
+
+```
+PUT /_plugins/geospatial/ip2geo/datasource/asn
+{
+  "endpoint": "https://geoip.maps.opensearch.org/v1/geolite2-asn/manifest.json",
+  "update_interval_in_days": 3
+}
+```
+
+2. Add a `dmarc` ingestion pipeline that use the `asn` IP2Geo data source:
+
+```
+PUT /_ingest/pipeline/dmarc
+{
+  "description": "Add ASN metadata for report source IP",
+  "processors": [
+    {
+      "ip2geo": {
+        "field": "feedback.record.row.source_ip",
+        "datasource": "asn"
+      }
+    }
+  ]
+}
+```
+
+3. Instruct `email-report-processor` to use the `dmarc` ingestion pipeline:
+
+```sh-session
+email-report-processor --dmarc-pipeline=dmarc
+```

--- a/lib/email_report_processor/base.rb
+++ b/lib/email_report_processor/base.rb
@@ -8,7 +8,7 @@ require 'zlib'
 
 module EmailReportProcessor
   class Base
-    attr_reader :index_name
+    attr_reader :index_name, :pipeline
 
     def initialize(client:)
       @client = client
@@ -22,7 +22,7 @@ module EmailReportProcessor
     def send_report(report)
       create_index unless index_exist?
 
-      @client.index(index: index_name, body: report)
+      @client.index(index: index_name, pipeline: pipeline, body: report)
     end
 
     def index_exist?

--- a/lib/email_report_processor/dmarc_rua.rb
+++ b/lib/email_report_processor/dmarc_rua.rb
@@ -12,6 +12,7 @@ module EmailReportProcessor
 
     def initialize(client:, options: {})
       @index_name = options[:dmarc_index] || DEFAULT_INDEX
+      @pipeline = options[:dmarc_pipeline]
       super(client: client)
     end
 

--- a/lib/email_report_processor/tlsrpt_rua.rb
+++ b/lib/email_report_processor/tlsrpt_rua.rb
@@ -10,6 +10,7 @@ module EmailReportProcessor
 
     def initialize(client:, options: {})
       @index_name = options[:tlsrpt_index] || DEFAULT_INDEX
+      @pipeline = options[:tlsrpt_pipeline]
       super(client: client)
     end
 


### PR DESCRIPTION
GeoLite2 ASN information can help filtering DMARC reports.  Add support
for passing an ingestion pipeline when adding reports, and document this
use case.
