### PR TITLE
Fix ingestion without pipeline

### DIFF
--- a/lib/email_report_processor/base.rb
+++ b/lib/email_report_processor/base.rb
@@ -22,7 +22,10 @@ module EmailReportProcessor
     def send_report(report)
       create_index unless index_exist?
 
-      @client.index(index: index_name, pipeline: pipeline, body: report)
+      params = { index: index_name, body: report }
+      params[:pipeline] = pipeline if pipeline
+
+      @client.index(params)
     end
 
     def index_exist?


### PR DESCRIPTION
We cannot pass `nil` for "no pipeline": if we provide a pipeline, it
must exist.  Rework the way we send reports to not pass a pipeline if
none was provided.
