### PR TITLE
Fix processing Mbox messages with a foreign encoding

### DIFF
--- a/lib/email_report_processor/mbox.rb
+++ b/lib/email_report_processor/mbox.rb
@@ -5,7 +5,7 @@ require 'mail'
 module EmailReportProcessor
   class Mbox
     def initialize(filename)
-      @io = File.open(filename)
+      @io = File.open(filename, 'rb')
       @current_message = ''
       @last_line = ''
     end
@@ -45,6 +45,10 @@ module EmailReportProcessor
 
     def generate_mail_from_current_message
       return nil if @current_message.empty?
+
+      @current_message.force_encoding('UTF-8')
+      @current_message.force_encoding('ISO-8859-1') unless @current_message.valid_encoding?
+      raise 'Encoding issue' unless @current_message.valid_encoding?
 
       mail = Mail.new(@current_message)
       @current_message = ''


### PR DESCRIPTION
A Mbox file may contain messages in various encoding, not necessarily
the one the user is currently using.  For this reason, it is advisable to
read the Mbox file as a binary file (that is with a ASCII8BIT encoding),
and attempt to adjust the encoding for each message in turn.

We first try to force the encoding to UTF-8 (which also accept ASCII7BIT
encoding), then ISO-8859-1 if the resulting string has not a valid
encoding.  This avoids choking on unknown encoding if non-reporting
messages are present in a report Mbox.
