### PR TITLE
Improve error reporting

### DIFF
--- a/exe/email-report-processor
+++ b/exe/email-report-processor
@@ -127,7 +127,7 @@ end
 unless message_reader.errors.empty?
   warn "The following #{message_reader.errors.count} message(s) count not be processed:"
   message_reader.errors.each do |error|
-    warn "  - #{error.message_id} (#{error.subject})"
+    warn "  - #{error.message_id} (#{error.subject}): #{error['X-Email-Report-Processor-Error']}"
   end
   exit 1
 end

--- a/lib/email_report_processor/message_reader.rb
+++ b/lib/email_report_processor/message_reader.rb
@@ -24,7 +24,8 @@ module EmailReportProcessor
       raise 'Missing Content-Disposition header' unless content_disposition
 
       process_attachment(content_disposition.filename, part.body.decoded)
-    rescue StandardError
+    rescue StandardError => e
+      message['X-Email-Report-Processor-Error'] = e.message
       errors << message
       nil
     end


### PR DESCRIPTION
Also report the reason of a message not being processed at the end of
operations.
