### PR TITLE
Add support for deduplicating reports

### DIFF
--- a/exe/email-report-processor
+++ b/exe/email-report-processor
@@ -14,6 +14,9 @@ options = {
   transport_options: { ssl: {} },
   mbox:              false,
   maildir:           false,
+  deduplicate_since: 'now-7d/d',
+  deduplicate_until: 'now',
+  deduplicate_count: 100,
 }
 
 class Progress
@@ -70,6 +73,17 @@ OptionParser.new do |opts|
   end
   opts.on('--tlsrpt-pipeline=PIPELINE', 'Ingest SMTP TLS reports using the provided PIPELINE') do |pipeline|
     options[:tlsrpt_pipeline] = pipeline
+  end
+
+  opts.separator("\nDeduplication options:")
+  opts.on('--dedup-since=SINCE', 'Deduplicate reports since (e.g. "now-1M")') do |dedup_since|
+    options[:deduplicate_since] = dedup_since
+  end
+  opts.on('--dedup-until=UNTIL', 'Deduplicate reports until (e.g. "now")') do |dedup_until|
+    options[:deduplicate_until] = dedup_until
+  end
+  opts.on('--dedup-count=COUNT', 'Find up to COUNT report ids in the deduplication interval') do |count|
+    options[:deduplicate_count] = count
   end
 
   opts.separator("\nMiscellaneous options:")

--- a/features/support/aruba.rb
+++ b/features/support/aruba.rb
@@ -40,6 +40,12 @@ class TestWebserver < Sinatra::Base
     200
   end
 
+  post '/dmarc-reports/_search' do
+    halt 200, { 'Content-Type' => 'application/json' }, <<~DATA
+      {"aggregations":{"report_ids":{"sum_other_doc_count": 0, "buckets": []}}}
+    DATA
+  end
+
   post '/dmarc-reports/_doc' do
     halt 201, { 'Content-Type' => 'application/json' }, <<~DATA
       {"_index": "dmarc-reports", "_id": "abcdefghijklmnopqrst", "_version": 1, "result": "created", "_shards": {"total": 2, "successful": 1, "failed": 0}, "_seq_no": 199, "_primary_term": 2}
@@ -48,6 +54,12 @@ class TestWebserver < Sinatra::Base
 
   head '/tlsrpt-reports' do
     200
+  end
+
+  post '/tlsrpt-reports/_search' do
+    halt 200, { 'Content-Type' => 'application/json' }, <<~DATA
+      {"aggregations":{"report_ids":{"sum_other_doc_count": 0, "buckets": []}}}
+    DATA
   end
 
   post '/tlsrpt-reports/_doc' do

--- a/lib/email_report_processor/processors/base.rb
+++ b/lib/email_report_processor/processors/base.rb
@@ -5,9 +5,10 @@ module EmailReportProcessor
     class Base
       attr_reader :index_name, :pipeline
 
-      def initialize(client:)
+      def initialize(client:, options:)
         @client = client
         @index_exist = nil
+        @options = options
       end
 
       def index_exist?
@@ -28,10 +29,52 @@ module EmailReportProcessor
         @index_exist = true
       end
 
+      def known_report_ids
+        @known_report_ids ||= _known_report_ids
+      end
+
+      # rubocop:disable Metrics/MethodLength
+      def _known_report_ids
+        return [] unless index_exist?
+
+        query = {
+          size:  0,
+          query: {
+            range: {
+              @date_range_field => {
+                gte: @options[:deduplicate_since],
+                lte: @options[:deduplicate_until],
+              },
+            },
+          },
+          aggs:  {
+            report_ids: {
+              terms: {
+                field: "#{@report_id_field}.keyword",
+                size:  @options[:deduplicate_count],
+              },
+            },
+          },
+        }
+
+        res = @client.search(index: index_name, body: query)
+
+        missed = res['aggregations']['report_ids']['sum_other_doc_count']
+
+        raise "Current deduplication settings would miss #{missed} documents. Aborting." unless missed.zero?
+
+        res['aggregations']['report_ids']['buckets'].map { |bucket| bucket['key'] }
+      end
+      # rubocop:enable Metrics/MethodLength
+
       def send_report(report)
+        return if known_report_ids.include?(report.report_id)
+
         report.parts.each do |part|
           send_part(part)
         end
+
+        known_report_ids << report.report_id
       end
 
       def send_part(part)

--- a/lib/email_report_processor/processors/dmarc.rb
+++ b/lib/email_report_processor/processors/dmarc.rb
@@ -10,7 +10,10 @@ module EmailReportProcessor
       def initialize(client:, options: {})
         @index_name = options[:dmarc_index] || DEFAULT_INDEX
         @pipeline = options[:dmarc_pipeline]
-        super(client: client)
+
+        @date_range_field = 'feedback.report_metadata.date_range.begin'
+        @report_id_field = 'feedback.report_metadata.report_id'
+        super
       end
 
       def index_mappings # rubocop:disable Metrics/MethodLength

--- a/lib/email_report_processor/processors/tlsrpt.rb
+++ b/lib/email_report_processor/processors/tlsrpt.rb
@@ -10,7 +10,10 @@ module EmailReportProcessor
       def initialize(client:, options: {})
         @index_name = options[:tlsrpt_index] || DEFAULT_INDEX
         @pipeline = options[:tlsrpt_pipeline]
-        super(client: client)
+
+        @date_range_field = 'date-range.start-datetime'
+        @report_id_field = 'report-id'
+        super
       end
 
       def index_mappings # rubocop:disable Metrics/MethodLength

--- a/lib/email_report_processor/reports/dmarc.rb
+++ b/lib/email_report_processor/reports/dmarc.rb
@@ -17,6 +17,10 @@ module EmailReportProcessor
         @records = [@report['feedback'].delete('record')].flatten.map { |record| Dmarc::Record.new(record) }
       end
 
+      def report_id
+        @report['feedback']['report_metadata']['report_id']
+      end
+
       def parts
         @records.map do |record|
           report = Marshal.load(Marshal.dump(@report))

--- a/lib/email_report_processor/reports/tlsrpt.rb
+++ b/lib/email_report_processor/reports/tlsrpt.rb
@@ -10,6 +10,10 @@ module EmailReportProcessor
         @policies = @report.delete('policies')
       end
 
+      def report_id
+        @report['report-id']
+      end
+
       def parts
         @policies.map do |policy|
           @report.merge({ 'policies' => policy })

--- a/spec/email_report_processor/processors/dmarc_spec.rb
+++ b/spec/email_report_processor/processors/dmarc_spec.rb
@@ -16,17 +16,27 @@ RSpec.describe EmailReportProcessor::Processors::Dmarc do
   describe '#send_report' do
     before do
       allow(processor).to receive(:send_part)
+      allow(processor).to receive(:known_report_ids).and_return(known_report_ids)
       processor.send_report(EmailReportProcessor::Reports::Dmarc.new(report))
     end
 
-    it { is_expected.to have_received(:send_part) }
+    context 'when the report does not already exist' do
+      let(:known_report_ids) { [] }
+
+      it { expect(processor).to have_received(:send_part) }
+    end
+
+    context 'when the report already exist' do
+      let(:known_report_ids) { ['76a4511632d34eb99e944bfa59537f71'] }
+
+      it { expect(processor).not_to have_received(:send_part) }
+    end
   end
 
   describe '#send_part' do
     before do
       indices = instance_double(OpenSearch::API::Indices::Actions)
-      allow(indices).to receive(:exists?).and_return(false)
-      allow(indices).to receive(:create)
+      allow(indices).to receive(:exists?).and_return(true)
       allow(client).to receive(:indices).and_return(indices)
       allow(client).to receive(:index)
       processor.send_part(part)
@@ -35,5 +45,16 @@ RSpec.describe EmailReportProcessor::Processors::Dmarc do
     let(:part) { double }
 
     it { expect(client).to have_received(:index).with({ index: 'dmarc-reports', body: part }) }
+  end
+
+  describe '#known_report_ids' do
+    before do
+      indices = instance_double(OpenSearch::API::Indices::Actions)
+      allow(indices).to receive(:exists?).and_return(true)
+      allow(client).to receive_messages(indices: indices, search: { 'aggregations' => { 'report_ids' => { 'buckets' => [], 'sum_other_doc_count' => 0 } } })
+      processor.known_report_ids
+    end
+
+    it { expect(client).to have_received(:search) }
   end
 end

--- a/spec/email_report_processor/processors/tlsrpt_spec.rb
+++ b/spec/email_report_processor/processors/tlsrpt_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe EmailReportProcessor::Processors::Tlsrpt do
   let(:client) { instance_double(OpenSearch::Client) }
   let(:report) { File.read('spec/fixtures/sample-reports/tlsrpt/google.com!example.com!1667520000!1667606399!001.json') }
 
+  before do
+    indices = instance_double(OpenSearch::API::Indices::Actions)
+    allow(indices).to receive(:exists?).and_return(false)
+    allow(indices).to receive(:create)
+    allow(client).to receive(:indices).and_return(indices)
+    allow(client).to receive(:index)
+  end
+
   describe '#send_report' do
     before do
       allow(processor).to receive(:send_part)

--- a/spec/email_report_processor/reports/dmarc_spec.rb
+++ b/spec/email_report_processor/reports/dmarc_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe EmailReportProcessor::Reports::Dmarc do
     described_class.new(File.read('spec/fixtures/sample-reports/dmarc/enterprise.protection.outlook.com!blogreen.org!1706572800!1706659200.xml'))
   end
 
+  describe '#report_id' do
+    it { is_expected.to have_attributes(report_id: '76a4511632d34eb99e944bfa59537f71') }
+  end
+
   describe '#parts' do
     subject { report.parts }
 

--- a/spec/email_report_processor/reports/tlsrpt_spec.rb
+++ b/spec/email_report_processor/reports/tlsrpt_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe EmailReportProcessor::Reports::Tlsrpt do
     described_class.new(File.read('spec/fixtures/sample-reports/tlsrpt/google.com!example.com!1667520000!1667606399!001.json'))
   end
 
+  describe '#report_id' do
+    it { is_expected.to have_attributes(report_id: '2022-11-04T00:00:00Z_example.com') }
+  end
+
   describe '#parts' do
     subject { report.parts }
 


### PR DESCRIPTION
From time to time, a report is delivered multiple times.  When this
happen, the duplicates are generally sent a few minutes after the first
message, with the same report (same content, same report ID), and the
same Message-ID, but can come from different servers and have a distinct
DKIM signature.

Add some detection mechanism to detect if a report has already been
ingested to avoid storing multiple instances of the same events and
provide more accurate information.

When batch-importing reports, it may be necessary to adjust the settings
for duplicates detection by using a date range that cover all relevant
reports and increasing the number of reports that can be found.
